### PR TITLE
Allow matching of ipv6 addresses in DCC CHAT/SEND

### DIFF
--- a/lib/Parse/IRC.pm
+++ b/lib/Parse/IRC.pm
@@ -51,7 +51,7 @@ my %dcc_types = (
     qr/^(?:CHAT|SEND)$/ => sub {
         my ($nick, $type, $args) = @_;
         my ($file, $addr, $port, $size);
-        return if !(($file, $addr, $port, $size) = $args =~ /^(".+"|[^ ]+) +(\d+) +(\d+)(?: +(\d+))?/);
+        return if !(($file, $addr, $port, $size) = $args =~ /^(".+"|[^ ]+) +([0-9a-fA-F:]+) +(\d+)(?: +(\d+))?/);
 
         if ($file =~ s/^"//) {
             $file =~ s/"$//;


### PR DESCRIPTION
Nowadays with IPv6 addresses becoming more and more prevalent, using DCC CHAT or DCC SEND with those, they simply specify the IPv6 address in human-readable form instead of as a number.

At least this is how irssi does it.
